### PR TITLE
fix: 3인조 멤버 공정 분배

### DIFF
--- a/src/matcher.test.ts
+++ b/src/matcher.test.ts
@@ -20,15 +20,15 @@ describe("createMatches", () => {
 		expect(pairs.every((pair) => pair.length === 2)).toBe(true);
 	});
 
-	test("홀수 인원일 때 마지막 조가 3인이 된다", () => {
+	test("홀수 인원일 때 한 조가 3인이 된다", () => {
 		const participants = createParticipants(5);
 		const history: MatchHistory = { matches: [] };
 
 		const pairs = createMatches(participants, history);
 
 		expect(pairs).toHaveLength(2);
-		expect(pairs[0]).toHaveLength(2);
-		expect(pairs[1]).toHaveLength(3);
+		const lengths = pairs.map((p) => p.length).sort();
+		expect(lengths).toEqual([2, 3]);
 	});
 
 	test("1명일 때 빈 배열을 반환한다", () => {

--- a/src/matcher.ts
+++ b/src/matcher.ts
@@ -61,6 +61,18 @@ export function createMatches(
 	const pairs: Participant[][] = [];
 
 	let shuffled = shuffle(participants);
+
+	// 홀수일 때 3인조 후보를 먼저 무작위로 선택
+	let thirdMember: Participant | null = null;
+	if (shuffled.length % 2 === 1) {
+		const randomIndex = Math.floor(Math.random() * shuffled.length);
+		thirdMember = shuffled[randomIndex];
+		shuffled = [
+			...shuffled.slice(0, randomIndex),
+			...shuffled.slice(randomIndex + 1),
+		];
+	}
+
 	let attempts = 0;
 	const maxAttempts = 100;
 
@@ -79,9 +91,10 @@ export function createMatches(
 		attempts = 0;
 	}
 
-	// 홀수 처리: 마지막 사람을 마지막 조에 추가
-	if (shuffled.length === 1 && pairs.length > 0) {
-		pairs[pairs.length - 1].push(shuffled[0]);
+	// 3인조 후보를 무작위 조에 추가
+	if (thirdMember && pairs.length > 0) {
+		const randomPairIndex = Math.floor(Math.random() * pairs.length);
+		pairs[randomPairIndex].push(thirdMember);
 	}
 
 	return pairs;


### PR DESCRIPTION
## Summary
- 홀수 인원 시 3인조 후보를 매칭 전에 먼저 무작위 선택
- 3인조가 될 조도 무작위로 선택

## 문제
기존 알고리즘에서 최근 많이 매칭된 사람이 reshuffle 과정에서 뒤로 밀려 3인조에 편중되는 문제 발생
- 5번 매칭 중 4번이 동일인이 3인조 (확률 0.16%)

## 해결
3인조 멤버를 매칭 로직과 분리하여 먼저 무작위 선택

## Test plan
- [x] `bun run test` 통과
- [ ] 워크플로우 여러 번 실행하여 3인조 멤버 분포 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)