### PR TITLE
refactor: 매칭 스케줄을 히스토리 기반으로 변경

### DIFF
--- a/data/roles.json
+++ b/data/roles.json
@@ -20,7 +20,7 @@
 		"displayName": "테스트 커피챗",
 		"roleId": "1482772179656376340",
 		"channelId": "1485256492520050760",
-		"schedule": "weekly",
+		"schedule": "manual",
 		"groupSize": 2
 	},
 	{

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,15 +46,22 @@ async function main() {
 	for (const role of targetRoles) {
 		console.log(`--- [${role.displayName}] 역할 처리 중 ---`);
 
+		// 1. 매칭 이력 로드
+		const history = await loadHistory(role.name);
+		const lastMatchDate = history.matches.at(-1)?.date;
+
 		// 스케줄 체크 (수동 실행 또는 dry-run 시 건너뜀)
-		if (!forceRun && !dryRun && !shouldRunToday(role.schedule)) {
-			console.log(
-				`${role.displayName}: 이번 주는 매칭 주가 아닙니다. 건너뜁니다.`,
-			);
-			continue;
+		if (!forceRun && !dryRun) {
+			const last = lastMatchDate ? new Date(lastMatchDate) : undefined;
+			if (!shouldRunToday(role.schedule, new Date(), last)) {
+				console.log(
+					`${role.displayName}: 아직 매칭 주기가 되지 않았습니다. 건너뜁니다.${lastMatchDate ? ` (마지막 매칭: ${lastMatchDate})` : ""}`,
+				);
+				continue;
+			}
 		}
 
-		// 1. 참여자 목록 조회
+		// 2. 참여자 목록 조회
 		const participants = await getParticipants(role.roleId);
 		console.log(
 			`${role.displayName}: 참여자 ${participants.length}명 조회 완료`,
@@ -66,9 +73,6 @@ async function main() {
 			);
 			continue;
 		}
-
-		// 2. 매칭 이력 로드
-		const history = await loadHistory(role.name);
 
 		// 3. 매칭 생성
 		const groups = createMatches(participants, history, {

--- a/src/schedule.test.ts
+++ b/src/schedule.test.ts
@@ -1,51 +1,50 @@
 import { describe, expect, test } from "bun:test";
-import { getISOWeekNumber, shouldRunToday } from "./schedule.ts";
+import { shouldRunToday } from "./schedule.ts";
 
 describe("shouldRunToday", () => {
-	test("weekly는 항상 true", () => {
-		expect(shouldRunToday("weekly", new Date("2026-01-05"))).toBe(true); // 월요일
-		expect(shouldRunToday("weekly", new Date("2026-02-16"))).toBe(true);
+	const today = new Date("2026-04-06T00:00:00Z");
+
+	test("manual은 항상 false", () => {
+		expect(shouldRunToday("manual", today)).toBe(false);
+		expect(shouldRunToday("manual", today, new Date("2025-01-01"))).toBe(false);
 	});
 
-	test("biweekly는 짝수 주에만 true", () => {
-		// 2026-01-05 = ISO week 2 (짝수) → true
-		const evenWeek = new Date("2026-01-05");
-		expect(shouldRunToday("biweekly", evenWeek)).toBe(true);
-
-		// 2026-01-12 = ISO week 3 (홀수) → false
-		const oddWeek = new Date("2026-01-12");
-		expect(shouldRunToday("biweekly", oddWeek)).toBe(false);
+	test("이력이 없으면 즉시 실행", () => {
+		expect(shouldRunToday("weekly", today)).toBe(true);
+		expect(shouldRunToday("biweekly", today)).toBe(true);
+		expect(shouldRunToday("monthly", today)).toBe(true);
 	});
 
-	test("monthly는 해당 월의 첫째 월요일에만 true", () => {
-		// 2026-02-02 = 첫째 월요일
-		expect(shouldRunToday("monthly", new Date("2026-02-02"))).toBe(true);
-
-		// 2026-02-09 = 둘째 월요일
-		expect(shouldRunToday("monthly", new Date("2026-02-09"))).toBe(false);
-
-		// 2026-02-03 = 화요일 (월요일이 아님)
-		expect(shouldRunToday("monthly", new Date("2026-02-03"))).toBe(false);
-
-		// 2026-03-02 = 첫째 월요일
-		expect(shouldRunToday("monthly", new Date("2026-03-02"))).toBe(true);
-	});
-});
-
-describe("getISOWeekNumber", () => {
-	test("연초 날짜의 주 번호를 올바르게 계산한다", () => {
-		// 2026-01-01 = 목요일, ISO week 1
-		expect(getISOWeekNumber(new Date("2026-01-01"))).toBe(1);
+	test("weekly는 마지막 매칭 후 7일 이상 경과 시 실행", () => {
+		// 7일 전 → 실행
+		expect(shouldRunToday("weekly", today, new Date("2026-03-30"))).toBe(true);
+		// 6일 전 → 대기
+		expect(shouldRunToday("weekly", today, new Date("2026-03-31"))).toBe(false);
+		// 14일 전 → 실행
+		expect(shouldRunToday("weekly", today, new Date("2026-03-23"))).toBe(true);
 	});
 
-	test("연말 날짜의 주 번호를 올바르게 계산한다", () => {
-		// 2025-12-29 = 월요일, ISO week 1 of 2026
-		expect(getISOWeekNumber(new Date("2025-12-29"))).toBe(1);
+	test("biweekly는 마지막 매칭 후 14일 이상 경과 시 실행", () => {
+		// 14일 전 → 실행
+		expect(shouldRunToday("biweekly", today, new Date("2026-03-23"))).toBe(
+			true,
+		);
+		// 13일 전 → 대기
+		expect(shouldRunToday("biweekly", today, new Date("2026-03-24"))).toBe(
+			false,
+		);
+		// 21일 전 → 실행
+		expect(shouldRunToday("biweekly", today, new Date("2026-03-16"))).toBe(
+			true,
+		);
 	});
 
-	test("중간 날짜의 주 번호를 올바르게 계산한다", () => {
-		// 2026-02-16 = 월요일
-		const weekNum = getISOWeekNumber(new Date("2026-02-16"));
-		expect(weekNum).toBe(8);
+	test("monthly는 마지막 매칭 후 28일 이상 경과 시 실행", () => {
+		// 28일 전 → 실행
+		expect(shouldRunToday("monthly", today, new Date("2026-03-09"))).toBe(true);
+		// 27일 전 → 대기
+		expect(shouldRunToday("monthly", today, new Date("2026-03-10"))).toBe(
+			false,
+		);
 	});
 });

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,44 +1,24 @@
 import type { MatchSchedule } from "./types.ts";
 
+const INTERVAL_DAYS: Record<Exclude<MatchSchedule, "manual">, number> = {
+	weekly: 7,
+	biweekly: 14,
+	monthly: 28,
+};
+
 /**
- * 주어진 스케줄에 따라 오늘 매칭을 실행해야 하는지 판단
+ * 마지막 매칭일 기준으로 오늘 매칭을 실행해야 하는지 판단
  */
 export function shouldRunToday(
 	schedule: MatchSchedule,
 	today: Date = new Date(),
+	lastMatchDate?: Date,
 ): boolean {
-	switch (schedule) {
-		case "weekly":
-			return true;
-		case "biweekly": {
-			// ISO 주 번호 기준 짝수 주
-			const weekNumber = getISOWeekNumber(today);
-			return weekNumber % 2 === 0;
-		}
-		case "monthly": {
-			// 해당 월의 첫째 월요일
-			return isFirstMondayOfMonth(today);
-		}
-	}
-}
+	if (schedule === "manual") return false;
+	if (!lastMatchDate) return true;
 
-/**
- * ISO 8601 주 번호 계산
- */
-export function getISOWeekNumber(date: Date): number {
-	const d = new Date(
-		Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+	const diffDays = Math.floor(
+		(today.getTime() - lastMatchDate.getTime()) / 86400000,
 	);
-	// 가장 가까운 목요일로 이동 (ISO 8601 기준)
-	d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
-	const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-	return Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
-}
-
-/**
- * 해당 월의 첫째 월요일인지 확인
- */
-function isFirstMondayOfMonth(date: Date): boolean {
-	if (date.getDay() !== 1) return false; // 월요일이 아니면 false
-	return date.getDate() <= 7; // 7일 이내의 월요일이면 첫째 월요일
+	return diffDays >= INTERVAL_DAYS[schedule];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface MatchingOptions {
 	groupSize?: number; // 기본 2
 }
 
-export type MatchSchedule = "weekly" | "biweekly" | "monthly";
+export type MatchSchedule = "weekly" | "biweekly" | "monthly" | "manual";
 
 export interface RoleConfig {
 	name: string; // slug (디렉토리명, autocomplete value)


### PR DESCRIPTION
## 요약

- 3/22에 매칭이 있었는데, 3/30에 또 매칭이 되는 문제가 발생했습니다. 그리고 4/6에는 또 매칭이 되지 않았습니다.
- 이 문제를 해결하기 위해서 매칭 스케줄 판단 방식을 ISO 주 번호 기반에서 **마지막 매칭일 기준 경과일** 방식으로 변경합니다
- `coffee-test` 역할의 스케줄을 `weekly`에서 `manual`로 변경하여 자동 매칭을 중단합니다. 테스트가 충분히 되었습니다.

## 변경 내용

### 스케줄 로직 변경 (`schedule.ts`)
- 기존: ISO 주 번호의 홀짝으로 biweekly 판단, 첫째 월요일로 monthly 판단
- 변경: `history.json`의 마지막 매칭일로부터 경과일 계산
  - `weekly`: 7일 이상 경과 시 실행
  - `biweekly`: 14일 이상 경과 시 실행
  - `monthly`: 28일 이상 경과 시 실행
  - `manual`: 자동 실행하지 않음 (수동 트리거만 가능)
- `getISOWeekNumber`, `isFirstMondayOfMonth` 함수 삭제

### 실행 흐름 변경 (`index.ts`)
- 매칭 이력 로드를 스케줄 체크보다 앞으로 이동하여 마지막 매칭일을 참조할 수 있도록 합니다

### `coffee-test` 자동 매칭 중단 (`roles.json`)
- `coffee-test` 역할의 schedule을 `manual`로 변경하여 cron 실행 시 건너뜁니다
- `workflow_dispatch`로 수동 트리거 시에는 기존대로 실행 가능합니다

## 배경

- ISO 주 번호 방식은 53주가 있는 해(2026년 등)에서 연말-연초 전환 시 3주 공백이 발생하는 문제가 있었습니다
- `coffee-test`가 `weekly`로 설정되어 biweekly 역할의 쉬는 주에도 같은 채널에 매칭 알림이 가는 문제가 있었습니다

## 테스트

- [x] `bun test` 전체 통과 (59 tests)
- [x] `bun run typecheck` 통과
- [x] `bun run lint` 통과