### PR TITLE
fix: 배포 시 사이트 빌드 누락 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Worker
 on:
   push:
     branches: [main]
-    paths: ["worker/**"]
+    paths: ["worker/**", "site/**"]
 
 jobs:
   deploy:
@@ -15,7 +15,15 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
-      - name: Install dependencies
+      - name: Install site dependencies
+        run: bun install
+        working-directory: site
+
+      - name: Build site
+        run: bun run build
+        working-directory: site
+
+      - name: Install worker dependencies
         run: bun install
         working-directory: worker
 

--- a/worker/wrangler.jsonc
+++ b/worker/wrangler.jsonc
@@ -1,5 +1,6 @@
 {
 	"name": "coffee",
+	"account_id": "94480614a6df7731f1e4491bdac5c440",
 	"main": "src/index.ts",
 	"compatibility_date": "2025-02-03",
 	"assets": {


### PR DESCRIPTION
`coffee.dalestudy.com` 접속 시 "Method Not Allowed"가 반환되는 문제를 수정합니다. Worker의 `wrangler.jsonc`가 `site/dist/`를 정적 자산으로 참조하지만, `deploy.yml`에서 Astro 사이트를 빌드하는 단계가 빠져 있어서 자산 없이 배포되고 있었습니다. 사이트 빌드 단계를 추가하고, `site/**` 변경 시에도 배포가 트리거되도록 경로를 확장했습니다. 또한 `wrangler.jsonc`에 `account_id`를 명시하여 의도하지 않은 계정으로 배포되는 실수를 방지합니다.

# Testing

1. PR 머지 후 GitHub Actions의 "Deploy Worker" 워크플로우가 정상 실행되는지 확인합니다.
2. 워크플로우 로그에서 "Build site" 단계가 Astro 빌드를 성공적으로 완료하는지 확인합니다.
3. 배포 완료 후 브라우저에서 `https://coffee.dalestudy.com`에 접속하여 웹사이트가 정상적으로 표시되는지 확인합니다.